### PR TITLE
Modify : Nav 로직 수정

### DIFF
--- a/src/components/common/Nav/Nav.tsx
+++ b/src/components/common/Nav/Nav.tsx
@@ -11,15 +11,19 @@ const Nav = () => {
 
   const [tab, setTab] = useRecoilState(tabState);
 
-  const currentPath = router.pathname;
+  const currentPath = router.pathname.split('/')[1];
 
-  useEffect(() => {
-    setTab(currentPath);
-  }, [currentPath]);
+  const tabHandler = () => {
+    currentPath === '' ? setTab('/') : setTab(`/${currentPath}`);
+  };
 
   const pageHandler = (path: string) => {
     router.push(path);
   };
+
+  useEffect(() => {
+    tabHandler();
+  }, [currentPath]);
 
   return (
     <StNav>


### PR DESCRIPTION
## :: 📌 최근 작업 주제 (하나 이상의 주제를 선택해주세요.)

- [ ] 기능 추가
- [ ] 리뷰 반영
- [ ] 리팩토링
- [x] 버그 수정
- [ ] 컨벤션 수정

<br />

## :: 🚩 구현 목표 (해당 브랜치에서 구현하고자 하는 하나의 목표를 설정합니다.)

- Nav 로직 수정

<br />

## :: 🧾 구현 사항 설명 (작업한 내용을 상세하게 기록합니다.)

1. Nav 로직 수정
- 기존 로직에서는 다이나믹 라우팅을 통한 페이지 전환시 대응 불가(/stores/1 이런식으로 페이지 전환이 일어날 경우 선택되었던 탭의 색이 꺼지는 이슈 발생)
- currentpath를 /를 기준으로 split하고 두번째 요소를 기준으로 setTab이 되도록 변경
- 하지만 / 즉 홈 화면일 경우 split으로 나누게 되면 빈값이 tab으로 설정되기 때문에 삼항연산자를 통해 빈 값일 경우 setTab('/') 아닐 경우 setTab(currentPath)로 구현