### PR TITLE
ADD : Store Detail 페이지 StoreInfo 컴포넌트 구현 완료

### DIFF
--- a/pages/stores/[storeId].tsx
+++ b/pages/stores/[storeId].tsx
@@ -1,6 +1,12 @@
 import styled from '@emotion/styled';
 import storesAPI from '@src/api/stores';
-import { IStore } from '@src/components/Home/Stores/types';
+import Dropdown from '@src/components/common/Dropdown/Dropdown';
+import { IStore } from '@src/components/Home/AllStores/types';
+import AvailableRobot from '@src/components/Stores/AvailableRobot';
+import MapNode from '@src/components/Stores/MapNode';
+import PeakTime from '@src/components/Stores/PeakTime';
+import StoreInfo from '@src/components/Stores/StoreInfo';
+
 import React from 'react';
 
 export async function getStaticPaths() {
@@ -19,18 +25,28 @@ export async function getStaticPaths() {
 }
 
 export async function getStaticProps({ params }: any) {
-  const response = await storesAPI.getStores(params.storeId);
+  const store = await storesAPI.getStores(params.storeId);
+  const stores = await storesAPI.getStores();
 
   return {
     props: {
-      store: response,
+      store: store,
+      stores: stores,
     },
   };
 }
 
-const Store = ({ store }: any) => {
-  console.log(store.stores);
-  return <StStore></StStore>;
+const Store = ({ store, stores }: any) => {
+  console.log(store);
+
+  return (
+    <StStore>
+      <StoreInfo store={store.stores} storeList={stores.stores} />
+      <PeakTime />
+      <MapNode />
+      <AvailableRobot />
+    </StStore>
+  );
 };
 
 const StStore = styled.div`
@@ -38,6 +54,8 @@ const StStore = styled.div`
   grid-template-columns: repeat(4, 1fr);
   grid-template-rows: repeat(2, 1fr);
   width: 100%;
+  height: 100%;
+  gap: 1vw;
 `;
 
 export default Store;

--- a/pages/stores/[storeId].tsx
+++ b/pages/stores/[storeId].tsx
@@ -1,7 +1,43 @@
+import styled from '@emotion/styled';
+import storesAPI from '@src/api/stores';
+import { IStore } from '@src/components/Home/Stores/types';
 import React from 'react';
 
-const Store = () => {
-  return <div></div>;
+export async function getStaticPaths() {
+  const response: any = await storesAPI.getStores();
+
+  const paths = response.stores.map((store: IStore) => ({
+    params: {
+      storeId: store.map_id,
+    },
+  }));
+
+  return {
+    paths,
+    fallback: false,
+  };
+}
+
+export async function getStaticProps({ params }: any) {
+  const response = await storesAPI.getStores(params.storeId);
+
+  return {
+    props: {
+      store: response,
+    },
+  };
+}
+
+const Store = ({ store }: any) => {
+  console.log(store.stores);
+  return <StStore></StStore>;
 };
+
+const StStore = styled.div`
+  display: grid;
+  grid-template-columns: repeat(4, 1fr);
+  grid-template-rows: repeat(2, 1fr);
+  width: 100%;
+`;
 
 export default Store;

--- a/pages/stores/index.tsx
+++ b/pages/stores/index.tsx
@@ -2,7 +2,7 @@ import styled from '@emotion/styled';
 import storesAPI from '@src/api/stores';
 import Dropdown from '@src/components/common/Dropdown/Dropdown';
 import { IStore, IStoreResponse } from '@src/components/Home/AllStores/types';
-import StoreMap from '@src/components/Stores/StoreMap';
+import Store from '@src/components/Stores/Store';
 import React from 'react';
 
 export async function getStaticProps() {
@@ -29,7 +29,7 @@ const Stores = ({ stores }: IProps) => {
       </StHeader>
       <StBody>
         {stores.stores.map((store: IStore) => (
-          <StoreMap key={store.map_id} store={store} />
+          <Store key={store.map_id} store={store} />
         ))}
       </StBody>
     </StStores>

--- a/pages/stores/index.tsx
+++ b/pages/stores/index.tsx
@@ -1,9 +1,12 @@
+import React, { useEffect } from 'react';
+import { useRecoilState, useSetRecoilState } from 'recoil';
 import styled from '@emotion/styled';
 import storesAPI from '@src/api/stores';
 import Dropdown from '@src/components/common/Dropdown/Dropdown';
 import { IStore, IStoreResponse } from '@src/components/Home/AllStores/types';
 import Store from '@src/components/Stores/Store';
-import React from 'react';
+import { storeNameState } from '@src/store/storeNameState';
+import { useRouter } from 'next/router';
 
 export async function getStaticProps() {
   const response = await storesAPI.getStores();
@@ -20,16 +23,27 @@ interface IProps {
 }
 
 const Stores = ({ stores }: IProps) => {
-  console.log(stores.stores);
+  const router = useRouter();
+
+  const setStoreName = useSetRecoilState(storeNameState);
+
+  const pageHandler = (storeName: string, storeId: string) => {
+    setStoreName(storeName);
+    router.push(`/stores/${storeId}`);
+  };
+
+  useEffect(() => {
+    setStoreName('전체매장');
+  }, []);
 
   return (
     <StStores>
       <StHeader>
-        <Dropdown stores={stores.stores} />
+        <Dropdown event={pageHandler} dataList={stores.stores} />
       </StHeader>
       <StBody>
         {stores.stores.map((store: IStore) => (
-          <Store key={store.map_id} store={store} />
+          <Store key={store.map_id} store={store} event={pageHandler} />
         ))}
       </StBody>
     </StStores>

--- a/src/components/Stores/AvailableRobot.tsx
+++ b/src/components/Stores/AvailableRobot.tsx
@@ -1,0 +1,17 @@
+import styled from '@emotion/styled';
+import React from 'react';
+
+const AvailableRobot = () => {
+  return <StAvailableRobot></StAvailableRobot>;
+};
+
+const StAvailableRobot = styled.div`
+  grid-area: 2 / 4 / 3 / 5;
+  padding: 1vw;
+  width: 100%;
+  background: ${({ theme }) => theme.color.white};
+  border-radius: 0.2604vw;
+  box-shadow: rgba(99, 99, 99, 0.2) 0vw 0.1042vw 0.4167vw 0vw;
+`;
+
+export default AvailableRobot;

--- a/src/components/Stores/MapNode.tsx
+++ b/src/components/Stores/MapNode.tsx
@@ -1,0 +1,17 @@
+import styled from '@emotion/styled';
+import React from 'react';
+
+const MapNode = () => {
+  return <StMapNode></StMapNode>;
+};
+
+const StMapNode = styled.div`
+  grid-area: 2 / 2 / 3 / 4;
+  padding: 1vw;
+  width: 100%;
+  background: ${({ theme }) => theme.color.white};
+  border-radius: 0.2604vw;
+  box-shadow: rgba(99, 99, 99, 0.2) 0vw 0.1042vw 0.4167vw 0vw;
+`;
+
+export default MapNode;

--- a/src/components/Stores/PeakTime.tsx
+++ b/src/components/Stores/PeakTime.tsx
@@ -1,0 +1,17 @@
+import styled from '@emotion/styled';
+import React from 'react';
+
+const PeakTime = () => {
+  return <StPeakTime></StPeakTime>;
+};
+
+const StPeakTime = styled.div`
+  grid-area: 1 / 2 / 2 / 5;
+  padding: 1vw;
+  width: 100%;
+  background: ${({ theme }) => theme.color.white};
+  border-radius: 0.2604vw;
+  box-shadow: rgba(99, 99, 99, 0.2) 0vw 0.1042vw 0.4167vw 0vw;
+`;
+
+export default PeakTime;

--- a/src/components/Stores/Store.tsx
+++ b/src/components/Stores/Store.tsx
@@ -1,5 +1,6 @@
 import styled from '@emotion/styled';
 import Image from 'next/image';
+import { useRouter } from 'next/router';
 import React from 'react';
 import { IStore } from '../Home/AllStores/types';
 
@@ -10,15 +11,21 @@ interface IProps {
 const Store = ({ store }: IProps) => {
   const { map_id, map_name, location } = store;
 
+  const router = useRouter();
+
+  const pageHandler = () => {
+    router.push(`/stores/${map_id}`);
+  };
+
   return (
-    <StStore>
+    <StStore onClick={pageHandler}>
       <StHeader>
         <StName>{map_name}</StName>
         <StLocation>{location}</StLocation>
       </StHeader>
       <StDevider />
       <StBody>
-        <StMapImg src={`/assets/images/map/map-background-${map_id}-monitoring.png`} alt="매장이미지" layout="fill" />
+        <StMapImg src={`/assets/images/map/map-background-${map_id}-monitoring.png`} alt="매장이미지" fill />
       </StBody>
     </StStore>
   );
@@ -40,13 +47,13 @@ const StHeader = styled.div`
 const StName = styled.p`
   margin-bottom: 0.2604vw;
   color: ${({ theme }) => theme.color.blue100};
-  font-size: 0.7292vw;
+  font-size: 1.0292vw;
   font-weight: 700;
 `;
 
 const StLocation = styled.p`
   color: ${({ theme }) => theme.color.blue};
-  font-size: 0.625vw;
+  font-size: 0.8256vw;
 `;
 
 const StDevider = styled.hr`
@@ -55,16 +62,16 @@ const StDevider = styled.hr`
 `;
 
 const StBody = styled.div`
-  margin: 1vw;
-  span {
-    position: unset !important;
-  }
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  position: relative;
 `;
 
 const StMapImg = styled(Image)`
   position: relative !important;
   object-fit: scale-down;
-  width: 100% !important;
+  width: 60% !important;
   height: 60% !important;
 `;
 

--- a/src/components/Stores/Store.tsx
+++ b/src/components/Stores/Store.tsx
@@ -1,24 +1,21 @@
 import styled from '@emotion/styled';
 import Image from 'next/image';
-import { useRouter } from 'next/router';
 import React from 'react';
 import { IStore } from '../Home/AllStores/types';
 
 interface IProps {
+  event: (arg1: string, arg2: string) => void;
   store: IStore;
 }
 
-const Store = ({ store }: IProps) => {
+const Store = ({ store, event }: IProps) => {
   const { map_id, map_name, location } = store;
 
-  const router = useRouter();
-
-  const pageHandler = () => {
-    router.push(`/stores/${map_id}`);
-  };
-
   return (
-    <StStore onClick={pageHandler}>
+    <StStore
+      onClick={() => {
+        event(map_name, map_id);
+      }}>
       <StHeader>
         <StName>{map_name}</StName>
         <StLocation>{location}</StLocation>

--- a/src/components/Stores/StoreInfo.tsx
+++ b/src/components/Stores/StoreInfo.tsx
@@ -1,7 +1,132 @@
+import styled from '@emotion/styled';
+import { storeNameState } from '@src/store/storeNameState';
+import Image from 'next/image';
+import { useRouter } from 'next/router';
 import React from 'react';
+import { useSetRecoilState } from 'recoil';
+import Dropdown from '../common/Dropdown/Dropdown';
+import { IStore } from '../Home/AllStores/types';
 
-const StoreInfo = () => {
-  return <div></div>;
+interface IProps {
+  store: IStore;
+  storeList: IStore;
+}
+
+const StoreInfo = ({ store, storeList }: IProps) => {
+  const { img_src, map_name, location, descirbe, map_id, login, start_node, wifi_id, wifi_pw, home } = store[0];
+
+  const router = useRouter();
+
+  const setStoreName = useSetRecoilState(storeNameState);
+
+  const pageHandler = (storeName: string, storeId: string) => {
+    setStoreName(storeName);
+    router.push(`/stores/${storeId}`);
+  };
+
+  const STORE_INFO = [
+    { id: 0, title: '설명', description: descirbe },
+    { id: 1, title: 'Map_id', description: map_id },
+    { id: 2, title: 'Login', description: login },
+    { id: 3, title: 'Start_node', description: start_node },
+    { id: 4, title: 'Wifi_id', description: wifi_id },
+    { id: 5, title: 'Wifi_pw', description: wifi_pw },
+    { id: 6, title: 'Home', description: home },
+  ];
+
+  return (
+    <StStoreInfo>
+      <StHeader>
+        <Dropdown dataList={storeList} event={pageHandler} />
+      </StHeader>
+      <StBody>
+        <StInfo>
+          <Image src={img_src} width={70} height={50} alt="가게로고" />
+          <StStore>
+            <StName>{map_name}</StName>
+            <StLocation>{location}</StLocation>
+          </StStore>
+        </StInfo>
+        <StDevider />
+        {STORE_INFO.map(({ id, title, description }) => (
+          <StDetailInfo key={id}>
+            <StTitle>{title}</StTitle>
+            <StDescription>{description}</StDescription>
+          </StDetailInfo>
+        ))}
+      </StBody>
+    </StStoreInfo>
+  );
 };
+
+const StStoreInfo = styled.div`
+  grid-area: 1 / 1 / 3 / 2;
+  padding: 1vw;
+  width: 100%;
+  background: ${({ theme }) => theme.color.white};
+  border-radius: 0.2604vw;
+  box-shadow: rgba(99, 99, 99, 0.2) 0vw 0.1042vw 0.4167vw 0vw;
+`;
+
+const StHeader = styled.div`
+  margin-bottom: 1vw;
+  width: fit-content;
+`;
+
+const StBody = styled.div`
+  display: flex;
+  align-items: center;
+  flex-direction: column;
+  padding: 1vw;
+  width: 100%;
+  border-radius: 5px;
+  border: ${({ theme }) => `1px solid ${theme.color.gray400}`};
+`;
+
+const StInfo = styled.div`
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  width: 100%;
+`;
+
+const StStore = styled.div`
+  width: 100%;
+`;
+
+const StName = styled.p`
+  color: ${({ theme }) => theme.color.blue100};
+  font-size: 0.9771vw;
+  font-weight: 700;
+`;
+
+const StLocation = styled.p`
+  margin-top: 5px;
+  color: ${({ theme }) => theme.color.blue};
+  font-size: 0.7729vw;
+`;
+
+const StDevider = styled.hr`
+  margin: 1vw 0;
+  width: 100%;
+  border: ${({ theme }) => `0.5px solid ${theme.color.gray400}`};
+`;
+
+const StDetailInfo = styled.div`
+  margin-bottom: 20px;
+  width: 100%;
+`;
+
+const StTitle = styled.p`
+  margin-bottom: 5px;
+  color: ${({ theme }) => theme.color.main};
+  font-size: 15px;
+  font-weight: 600;
+`;
+
+const StDescription = styled.p`
+  font-size: 14px;
+  color: ${({ theme }) => theme.color.gray600};
+`;
 
 export default StoreInfo;

--- a/src/components/Stores/StoreInfo.tsx
+++ b/src/components/Stores/StoreInfo.tsx
@@ -1,0 +1,7 @@
+import React from 'react';
+
+const StoreInfo = () => {
+  return <div></div>;
+};
+
+export default StoreInfo;

--- a/src/components/common/Dropdown/Dropdown.tsx
+++ b/src/components/common/Dropdown/Dropdown.tsx
@@ -1,18 +1,23 @@
+import React, { useRef, useState } from 'react';
 import styled from '@emotion/styled';
 import { IStore } from '@src/components/Home/AllStores/types';
 import useOnClickOutside from '@src/hooks/useOnClickOutside';
-import React, { useRef, useState } from 'react';
+import { useRecoilValue } from 'recoil';
+import { storeNameState } from '@src/store/storeNameState';
 
 interface IProps {
-  stores: IStore;
+  event: (arg1: string, arg2: string) => void;
+  dataList: IStore;
 }
 
-const Dropdown = ({ stores }: IProps) => {
+const Dropdown = ({ dataList, event }: IProps) => {
   const [isOpen, setisOpen] = useState<boolean>(false);
+
+  const storeName = useRecoilValue(storeNameState);
 
   const ref = useRef<HTMLDivElement>(null);
 
-  const modalHandler = () => {
+  const dropdownHandler = () => {
     setisOpen(!isOpen);
   };
 
@@ -22,12 +27,19 @@ const Dropdown = ({ stores }: IProps) => {
 
   return (
     <StDropdown ref={ref}>
-      <StSelected isOpen={isOpen} onClick={modalHandler}>
-        드롭다운
+      <StSelected isOpen={isOpen} onClick={dropdownHandler}>
+        {storeName}
       </StSelected>
       <StSelect isOpen={isOpen}>
-        {stores.map(({ map_name, map_id }: IStore) => (
-          <StOption key={map_id}>{map_name}</StOption>
+        {dataList.map(({ map_name, map_id }: IStore) => (
+          <StOption
+            onClick={() => {
+              dropdownHandler();
+              event(map_name, map_id);
+            }}
+            key={map_id}>
+            {map_name}
+          </StOption>
         ))}
       </StSelect>
     </StDropdown>
@@ -40,7 +52,7 @@ const StDropdown = styled.div`
 
 const StSelected = styled.button<{ isOpen: boolean }>`
   position: relative;
-  padding: 0 16px;
+  padding: 0 5px;
   width: 120px;
   height: 30px;
   background: ${({ theme, isOpen }) => (isOpen ? theme.color.main : theme.color.sub)};
@@ -49,7 +61,7 @@ const StSelected = styled.button<{ isOpen: boolean }>`
   border-radius: 5px;
   border-bottom-left-radius: ${({ isOpen }) => (isOpen ? '0px' : '5px')};
   border-bottom-right-radius: ${({ isOpen }) => (isOpen ? '0px' : '5px')};
-  font-size: 13px;
+  font-size: 11px;
   z-index: 2;
   cursor: pointer;
 

--- a/src/store/storeNameState.ts
+++ b/src/store/storeNameState.ts
@@ -1,0 +1,6 @@
+import { atom } from 'recoil';
+
+export const storeNameState = atom<number | string>({
+  key: 'storeNameState',
+  default: '전체매장',
+});


### PR DESCRIPTION
## :: 📌 최근 작업 주제 (하나 이상의 주제를 선택해주세요.)

- [x] 기능 추가
- [ ] 리뷰 반영
- [ ] 리팩토링
- [ ] 버그 수정
- [ ] 컨벤션 수정

<br />

## :: 🚩 구현 목표 (해당 브랜치에서 구현하고자 하는 하나의 목표를 설정합니다.)

- StoresDetail 페이지 StoresInfo 컴포넌트 구현 

<br />

## :: 🧾 구현 사항 설명 (작업한 내용을 상세하게 기록합니다.)

1. StoresDetail 페이지 StoresInfo 컴포넌트 구현
- dropdown을 공용 컴포넌트로 사용하기 위해 사용되는 데이터를 상위 컴포넌트에서 props로 내려주는 형식으로 로직 수정
- StoreInfo에 사용되는 detail한 정보들은 배열 형식의 상수데이터 안에 넣고 매핑하여 렌더링
