### PR TITLE
ADD : Error Detail 페이지 레이아웃 구현 

### DIFF
--- a/pages/error/[errorId].tsx
+++ b/pages/error/[errorId].tsx
@@ -1,7 +1,105 @@
-import React from 'react';
+import styled from '@emotion/styled';
+import errorAPI from '@src/api/error';
+import storesAPI from '@src/api/stores';
+import ErrorInfo from '@src/components/Error/ErrorInfo';
+import ErrorList from '@src/components/Error/ErrorList';
+import ErrorRecentList from '@src/components/Error/ErrorRecentList';
+import ErrorResolveList from '@src/components/Error/ErrorResolveList';
+import ErrorSolution from '@src/components/Error/ErrorSolution';
+import ErrorStatus from '@src/components/Error/ErrorStatus';
+import ServingInfo from '@src/components/Error/ServingInfo';
+import { errorListState } from '@src/store/errorListState';
+import { errorState } from '@src/store/errorState';
+import { IErrorMsg } from '@src/types/error';
+import { useRouter } from 'next/router';
+import React, { useEffect, useState } from 'react';
+import { useMutation } from 'react-query';
+import { useRecoilState, useRecoilValue } from 'recoil';
 
-const index = () => {
-  return <div></div>;
+export async function getServerSideProps() {
+  const stores = await storesAPI.getStores();
+
+  const errors = await errorAPI.getErrorList();
+
+  return {
+    props: {
+      stores: stores,
+      errors: errors,
+    },
+  };
+}
+
+interface IProps {
+  stores: IResponse;
+  errors: any;
+}
+
+const ErrorDetail = ({ stores, errors }: IProps) => {
+  const { query } = useRouter();
+  const [errorList, setErrorList] = useRecoilState(errorListState);
+  const [mapId, setMapId] = useState<number>(0);
+  const [errorDetail, setErrorDetail] = useState({});
+  const errorMsg = useRecoilValue(errorState);
+
+  const mapIdHandler = (mapName: string, mapId: string) => {
+    setMapId(Number(mapId));
+  };
+
+  const { mutate: postDates, isLoading: errorListLoading } = useMutation((data: any) => errorAPI.postErrorDates(data), {
+    onSuccess: (data) => {
+      setErrorList(data.error_notice);
+    },
+  });
+
+  const { mutate: postErrorMsg, isLoading: errorMsgLoading } = useMutation(
+    (data: IErrorMsg) => errorAPI.postErrorDetail(data),
+    {
+      onSuccess: (data) => {
+        setErrorDetail(data);
+      },
+    },
+  );
+
+  useEffect(() => {
+    postErrorMsg(errorMsg);
+  }, []);
+
+  const handleClickDateInfo = (dates: any) => {
+    if (mapId === 0) {
+      return window.alert('검색하실 매장을 선택해주세요');
+    }
+
+    const data = { ...dates, map_id: mapId };
+
+    postDates(data);
+  };
+
+  return (
+    <StErrorDetail>
+      <ErrorList
+        stores={stores}
+        errorList={errorList}
+        isLoading={errorListLoading}
+        handleClickDateInfo={handleClickDateInfo}
+        mapIdHandler={mapIdHandler}
+        errorId={query.errorId}
+      />
+      <ErrorStatus />
+      <ErrorRecentList />
+      <ErrorInfo />
+      <ServingInfo />
+      <ErrorSolution />
+      <ErrorResolveList />
+    </StErrorDetail>
+  );
 };
 
-export default index;
+const StErrorDetail = styled.div`
+  width: 100%;
+  display: grid;
+  grid-template-columns: repeat(8, 1fr);
+  grid-template-rows: repeat(4, 1fr);
+  gap: 1vw;
+`;
+
+export default ErrorDetail;

--- a/pages/error/index.tsx
+++ b/pages/error/index.tsx
@@ -1,14 +1,13 @@
 import React, { useEffect, useState } from 'react';
 import { motion } from 'framer-motion';
 import styled from '@emotion/styled';
-import ErrorList from '@src/components/Error/ErrorList/ErrorList';
+import ErrorList from '@src/components/Error/ErrorList';
 import storesAPI from '@src/api/stores';
 import errorAPI from '@src/api/error';
 import { useRecoilState } from 'recoil';
-import { errorsState } from '@src/store/errorsState';
+import { errorListState } from '@src/store/errorListState';
 import { useMutation } from 'react-query';
 import { IErrorList } from '@src/types/error';
-import LineBarChart from '@src/components/common/LineBarChart/LineBarChart';
 
 export async function getStaticProps() {
   const stores = await storesAPI.getStores();
@@ -29,7 +28,7 @@ interface IProps {
 }
 
 const Error = ({ stores, errors }: IProps) => {
-  const [errorList, setErrorList] = useRecoilState(errorsState);
+  const [errorList, setErrorList] = useRecoilState(errorListState);
   const [mapId, setMapId] = useState<number>(0);
 
   useEffect(() => {

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -1,6 +1,6 @@
 import styled from '@emotion/styled';
 import { motion } from 'framer-motion';
-import { errorsState } from '@src/store/errorsState';
+import { errorListState } from '@src/store/errorListState';
 import { useEffect } from 'react';
 import { useRecoilState } from 'recoil';
 import homeAPI from '@src/api/home';
@@ -38,7 +38,7 @@ interface IProps {
 }
 
 const Home = ({ serving, stores, errorStatus, allErrors }: IProps) => {
-  const [errorList, setErrorList] = useRecoilState(errorsState);
+  const [errorList, setErrorList] = useRecoilState(errorListState);
 
   useEffect(() => {
     setErrorList(allErrors.error_notice);

--- a/src/api/apis.ts
+++ b/src/api/apis.ts
@@ -8,6 +8,7 @@ const API = {
   getRobotsDetail: '/api/monitoring-system/robot/map_id',
   getErrorList: '/api/monitoring-system/error-statistic',
   postErrorDates: '/api/monitoring-system/error-statistic',
+  postErrorDetail: '/api/monitoring-system/error-detail',
 };
 
 export default API;

--- a/src/api/error.ts
+++ b/src/api/error.ts
@@ -1,5 +1,6 @@
 import client from './client';
 import API from './apis';
+import { IErrorMsg } from '@src/types/error';
 
 const errorAPI = {
   getErrorList: () => {
@@ -7,6 +8,9 @@ const errorAPI = {
   },
   postErrorDates: (data: any) => {
     return client.post(`${API.postErrorDates}`, data);
+  },
+  postErrorDetail: (data: IErrorMsg) => {
+    return client.post(`${API.postErrorDetail}`, data);
   },
 };
 

--- a/src/components/Error/Error.tsx
+++ b/src/components/Error/Error.tsx
@@ -1,5 +1,7 @@
 import styled from '@emotion/styled';
+import { errorState } from '@src/store/errorState';
 import { useRouter } from 'next/router';
+import { useSetRecoilState } from 'recoil';
 
 interface IProps {
   created_at: string;
@@ -9,18 +11,25 @@ interface IProps {
   error_type: string;
   map_id: string;
   robot_id: string;
+  errorId?: string;
 }
 
-const Error = ({ created_at, current_node, error_id, error_msg, error_type, map_id, robot_id }: IProps) => {
+const Error = ({ created_at, current_node, error_id, error_msg, error_type, map_id, robot_id, errorId }: IProps) => {
   const router = useRouter();
+
+  const setErrorState = useSetRecoilState(errorState);
 
   const pageHandler = (errorId: string) => {
     router.push(`/error/${errorId}`);
   };
 
+  const errorMsg = { created_at, error_id, error_type, map_id, robot_id };
+
   return (
     <StError
+      isSame={errorId === error_id}
       onClick={() => {
+        setErrorState(errorMsg);
         pageHandler(error_id);
       }}>
       <StHeader>
@@ -39,17 +48,17 @@ const Error = ({ created_at, current_node, error_id, error_msg, error_type, map_
   );
 };
 
-const StError = styled.div`
+const StError = styled.div<{ isSame: boolean }>`
   margin-bottom: 1vw;
   padding: 1vw;
   width: 100%;
-  background: ${({ theme }) => theme.color.white};
+  background: ${({ theme, isSame }) => (isSame ? theme.color.gray200 : theme.color.white)};
   border-radius: 0.2604vw;
   box-shadow: rgba(99, 99, 99, 0.2) 0vw 0.1042vw 0.4167vw 0vw;
   cursor: pointer;
 
   :hover {
-    background: ${({ theme }) => theme.color.gray100};
+    background: ${({ theme, isSame }) => (isSame ? theme.color.gray200 : theme.color.gray100)};
   }
 `;
 

--- a/src/components/Error/ErrorInfo.tsx
+++ b/src/components/Error/ErrorInfo.tsx
@@ -1,0 +1,18 @@
+import styled from '@emotion/styled';
+import React from 'react';
+
+const ErrorInfo = () => {
+  return <StErrorInfo>에러 인포</StErrorInfo>;
+};
+
+const StErrorInfo = styled.div`
+  padding: 1vw;
+  width: 100%;
+  display: grid;
+  grid-area: 1 / 7 / 2 / 9;
+  background: ${({ theme }) => theme.color.white};
+  border-radius: 0.2604vw;
+  box-shadow: rgba(99, 99, 99, 0.2) 0vw 0.1042vw 0.4167vw 0vw;
+`;
+
+export default ErrorInfo;

--- a/src/components/Error/ErrorList.tsx
+++ b/src/components/Error/ErrorList.tsx
@@ -1,7 +1,7 @@
 import styled from '@emotion/styled';
 import React, { useState } from 'react';
-import Dropdown from '../../common/Dropdown/Dropdown';
-import Calendar from '../../common/Calendar/Calendar';
+import Dropdown from '../common/Dropdown/Dropdown';
+import Calendar from '../common/Calendar/Calendar';
 import Error from './Error';
 
 import Spinner from '@src/components/common/Spinner';
@@ -9,13 +9,13 @@ import Spinner from '@src/components/common/Spinner';
 interface IProps {
   stores: IResponse;
   errorList: IErrorNotice[];
-
   isLoading: boolean;
   handleClickDateInfo: (arg: any) => void;
   mapIdHandler: (arg1: string, arg2: string) => void;
+  errorId?: string | string[] | undefined;
 }
 
-const ErrorList = ({ stores, errorList, isLoading, handleClickDateInfo, mapIdHandler }: IProps) => {
+const ErrorList = ({ stores, errorList, isLoading, handleClickDateInfo, mapIdHandler, errorId }: IProps) => {
   const date = new Date();
   const year = date.getFullYear();
   const month = date.getMonth();
@@ -40,9 +40,9 @@ const ErrorList = ({ stores, errorList, isLoading, handleClickDateInfo, mapIdHan
         {isLoading ? (
           <Spinner />
         ) : errorList.length === 0 ? (
-          <StNull>해당 조건에 맞는 에러가 존재하지 않습니다 :(</StNull>
+          <StNull>해당 조건에 맞는 에러가 존재하지 않습니다:(</StNull>
         ) : (
-          errorList.map((error: any) => <Error key={error.error_id} {...error} />)
+          errorList.map((error: any) => <Error key={error.error_id} {...error} errorId={errorId} />)
         )}
       </StBody>
     </StErrorList>

--- a/src/components/Error/ErrorRecentList.tsx
+++ b/src/components/Error/ErrorRecentList.tsx
@@ -1,0 +1,18 @@
+import styled from '@emotion/styled';
+import React from 'react';
+
+const ErrorRecentList = () => {
+  return <StErrorRecentList>최근 에러 리스트</StErrorRecentList>;
+};
+
+const StErrorRecentList = styled.div`
+  padding: 1vw;
+  width: 100%;
+  display: grid;
+  grid-area: 1 / 5 / 3 / 7;
+  background: ${({ theme }) => theme.color.white};
+  border-radius: 0.2604vw;
+  box-shadow: rgba(99, 99, 99, 0.2) 0vw 0.1042vw 0.4167vw 0vw;
+`;
+
+export default ErrorRecentList;

--- a/src/components/Error/ErrorResolveList.tsx
+++ b/src/components/Error/ErrorResolveList.tsx
@@ -1,0 +1,18 @@
+import styled from '@emotion/styled';
+import React from 'react';
+
+const ErrorResolveList = () => {
+  return <StErrorResolveList>해결 리스트</StErrorResolveList>;
+};
+
+const StErrorResolveList = styled.div`
+  padding: 1vw;
+  width: 100%;
+  display: grid;
+  grid-area: 3 / 7 / 5 / 9;
+  background: ${({ theme }) => theme.color.white};
+  border-radius: 0.2604vw;
+  box-shadow: rgba(99, 99, 99, 0.2) 0vw 0.1042vw 0.4167vw 0vw;
+`;
+
+export default ErrorResolveList;

--- a/src/components/Error/ErrorSolution.tsx
+++ b/src/components/Error/ErrorSolution.tsx
@@ -1,0 +1,18 @@
+import styled from '@emotion/styled';
+import React from 'react';
+
+const ErrorSolution = () => {
+  return <StErrorSolution>에러 솔루션</StErrorSolution>;
+};
+
+const StErrorSolution = styled.div`
+  padding: 1vw;
+  width: 100%;
+  display: grid;
+  grid-area: 3 / 5 / 5 / 7;
+  background: ${({ theme }) => theme.color.white};
+  border-radius: 0.2604vw;
+  box-shadow: rgba(99, 99, 99, 0.2) 0vw 0.1042vw 0.4167vw 0vw;
+`;
+
+export default ErrorSolution;

--- a/src/components/Error/ErrorStatus.tsx
+++ b/src/components/Error/ErrorStatus.tsx
@@ -1,0 +1,18 @@
+import styled from '@emotion/styled';
+import React from 'react';
+
+const ErrorStatus = () => {
+  return <StErrorStatus>에러 스텟</StErrorStatus>;
+};
+
+const StErrorStatus = styled.div`
+  padding: 1vw;
+  width: 100%;
+  display: grid;
+  grid-area: 1 / 3 / 5 / 5;
+  background: ${({ theme }) => theme.color.white};
+  border-radius: 0.2604vw;
+  box-shadow: rgba(99, 99, 99, 0.2) 0vw 0.1042vw 0.4167vw 0vw;
+`;
+
+export default ErrorStatus;

--- a/src/components/Error/ServingInfo.tsx
+++ b/src/components/Error/ServingInfo.tsx
@@ -1,0 +1,18 @@
+import styled from '@emotion/styled';
+import React from 'react';
+
+const ServingInfo = () => {
+  return <StServingInfo>서빙 인포</StServingInfo>;
+};
+
+const StServingInfo = styled.div`
+  padding: 1vw;
+  width: 100%;
+  display: grid;
+  grid-area: 2 / 7 / 3 / 9;
+  background: ${({ theme }) => theme.color.white};
+  border-radius: 0.2604vw;
+  box-shadow: rgba(99, 99, 99, 0.2) 0vw 0.1042vw 0.4167vw 0vw;
+`;
+
+export default ServingInfo;

--- a/src/store/errorListState.ts
+++ b/src/store/errorListState.ts
@@ -1,0 +1,6 @@
+import { atom } from 'recoil';
+
+export const errorListState = atom<IErrorNotice[]>({
+  key: 'errorListState',
+  default: [],
+});

--- a/src/store/errorState.ts
+++ b/src/store/errorState.ts
@@ -1,0 +1,13 @@
+import { IErrorMsg } from '@src/types/error';
+import { atom } from 'recoil';
+
+export const errorState = atom<IErrorMsg>({
+  key: 'errorState',
+  default: {
+    created_at: '',
+    error_id: '',
+    error_type: '',
+    map_id: '',
+    robot_id: '',
+  },
+});

--- a/src/store/errorsState.ts
+++ b/src/store/errorsState.ts
@@ -1,6 +1,0 @@
-import { atom } from 'recoil';
-
-export const errorsState = atom<IErrorNotice[]>({
-  key: 'errorsState',
-  default: [],
-});

--- a/src/types/error.ts
+++ b/src/types/error.ts
@@ -57,3 +57,11 @@ export type IErrorList = {
   sleep_long: null | IObj;
   under_voltage: null | IObj;
 };
+
+export type IErrorMsg = {
+  created_at: string;
+  error_id: string;
+  error_type: string;
+  map_id: string;
+  robot_id: string;
+};


### PR DESCRIPTION
## :: 📌 최근 작업 주제 (하나 이상의 주제를 선택해주세요.)

- [x] 기능 추가
- [ ] 리뷰 반영
- [ ] 리팩토링
- [ ] 버그 수정
- [ ] 컨벤션 수정

<br />

## :: 🚩 구현 목표 (해당 브랜치에서 구현하고자 하는 하나의 목표를 설정합니다.)

- Error Detail 페이지 레이아웃 구현

<br />

## :: 🧾 구현 사항 설명 (작업한 내용을 상세하게 기록합니다.)

1.  Error Detail 페이지 레이아웃 구현
- grid를 이용한 레이아웃 구현

2. Error Detail 페이지 내에서 에러리스트 구현
- 에러 페이지에서 에러 메세지를 클릭할 경우 에러 디테일 페이지로 이동하게끔 구현
- 서버에서 받은 에러 리스트를 그대로 가지고 detail 페이지에서도 똑같이 리스트를 렌더링 하기 때문에 에러 리스트를 리코일을 이용해 전역에서 관리
- 에러메세지를 누르고 해당 에러 메세지에 대한 자세한 내용을 error detail 페이지에서 렌더링하는데 해당 에러에 대한 데이터를 get 메소드를 통해 받는 것이 아닌 post를 이용해 에러 메세지에 대한 정보(error_id, error_type, error_msg 등) 을 post하고 해당 에러에 대한 데이터를 받는 구조로 렌더링
- 좋은 방법은 아니지만 백엔드 측에서 path parameter를 이용한 데이터를 내려주는 방법을 모른다 하여 이런 구조로 데이터를 받기로 결정