### PR TITLE
ADD : Error Stat 컴포넌트 구현 완료

### DIFF
--- a/pages/error/[errorId].tsx
+++ b/pages/error/[errorId].tsx
@@ -1,3 +1,4 @@
+import React, { useEffect, useState } from 'react';
 import styled from '@emotion/styled';
 import errorAPI from '@src/api/error';
 import storesAPI from '@src/api/stores';
@@ -12,7 +13,6 @@ import { errorListState } from '@src/store/errorListState';
 import { errorState } from '@src/store/errorState';
 import { IErrorMsg } from '@src/types/error';
 import { useRouter } from 'next/router';
-import React, { useEffect, useState } from 'react';
 import { useMutation } from 'react-query';
 import { useRecoilState, useRecoilValue } from 'recoil';
 
@@ -39,7 +39,10 @@ const ErrorDetail = ({ stores, errors }: IProps) => {
   const [errorList, setErrorList] = useRecoilState(errorListState);
   const [mapId, setMapId] = useState<number>(0);
   const [errorDetail, setErrorDetail] = useState({});
+  const error = useRecoilValue(errorState);
   const errorMsg = useRecoilValue(errorState);
+
+  console.log(errorMsg);
 
   const mapIdHandler = (mapName: string, mapId: string) => {
     setMapId(Number(mapId));
@@ -62,7 +65,7 @@ const ErrorDetail = ({ stores, errors }: IProps) => {
 
   useEffect(() => {
     postErrorMsg(errorMsg);
-  }, []);
+  }, [query.errorId]);
 
   const handleClickDateInfo = (dates: any) => {
     if (mapId === 0) {
@@ -84,7 +87,7 @@ const ErrorDetail = ({ stores, errors }: IProps) => {
         mapIdHandler={mapIdHandler}
         errorId={query.errorId}
       />
-      <ErrorStatus />
+      <ErrorStatus errorInfo={errorDetail && errorDetail.error_info} />
       <ErrorRecentList />
       <ErrorInfo />
       <ServingInfo />

--- a/src/components/Error/ErrorStatus.tsx
+++ b/src/components/Error/ErrorStatus.tsx
@@ -1,8 +1,33 @@
 import styled from '@emotion/styled';
+import { IErrorInfo } from '@src/types/error';
 import React from 'react';
 
-const ErrorStatus = () => {
-  return <StErrorStatus>에러 스텟</StErrorStatus>;
+interface IProps {
+  errorInfo: IErrorInfo;
+}
+
+const ErrorStatus = ({ errorInfo }: IProps) => {
+  const target = errorInfo && errorInfo.robot_path.split(',')[0].split('!');
+
+  return (
+    <StErrorStatus>
+      <StHeader>에러 스탯</StHeader>
+      <StBody>
+        <StTitle>최근 목적지</StTitle>
+        <StDescription>: {errorInfo && errorInfo.recent_table}번 테이블</StDescription>
+        <StTitle>최근 배터리</StTitle>
+        <StDescription>: {errorInfo && errorInfo.battery}</StDescription>
+        <StTitle>최근 경로</StTitle>
+        <StDescription>: {errorInfo && errorInfo.robot_path}</StDescription>
+        <StTitle>최근 Final target</StTitle>
+        <StDescription>
+          : {target && target[0]}, {target && target[1]}
+        </StDescription>
+        <StTitle>Map 상황</StTitle>
+        <StDescription>: {errorInfo && errorInfo.recent_table}</StDescription>
+      </StBody>
+    </StErrorStatus>
+  );
 };
 
 const StErrorStatus = styled.div`
@@ -13,6 +38,35 @@ const StErrorStatus = styled.div`
   background: ${({ theme }) => theme.color.white};
   border-radius: 0.2604vw;
   box-shadow: rgba(99, 99, 99, 0.2) 0vw 0.1042vw 0.4167vw 0vw;
+  word-wrap: break-word;
+  white-space: nowrap;
+  text-overflow: ellipsis;
+`;
+
+const StHeader = styled.p`
+  margin-bottom: 0.5vw;
+  font-size: 16px;
+  font-weight: 500;
+`;
+
+const StBody = styled.div`
+  width: 100%;
+  height: 80vh;
+  word-wrap: break-word;
+  overflow: auto;
+`;
+
+const StTitle = styled.p`
+  margin-bottom: 0.5vw;
+  color: ${({ theme }) => theme.color.gray700};
+  font-size: 15px;
+`;
+
+const StDescription = styled.p`
+  margin-bottom: 1vw;
+  color: ${({ theme }) => theme.color.main};
+  font-size: 14px;
+  font-weight: 600;
 `;
 
 export default ErrorStatus;

--- a/src/types/error.ts
+++ b/src/types/error.ts
@@ -65,3 +65,10 @@ export type IErrorMsg = {
   map_id: string;
   robot_id: string;
 };
+
+export type IErrorInfo = {
+  battery: string;
+  map_existence: string;
+  recent_table: string;
+  robot_path: string;
+};


### PR DESCRIPTION
## :: 📌 최근 작업 주제 (하나 이상의 주제를 선택해주세요.)

- [x] 기능 추가
- [ ] 리뷰 반영
- [ ] 리팩토링
- [ ] 버그 수정
- [ ] 컨벤션 수정

<br />

## :: 🚩 구현 목표 (해당 브랜치에서 구현하고자 하는 하나의 목표를 설정합니다.)

- Error Stat 컴포넌트 구현 

<br />

## :: 🧾 구현 사항 설명 (작업한 내용을 상세하게 기록합니다.)

1. Error Stat 컴포넌트 구현 
- Error_info 데이터를 서버로부터 전달 받아 렌더링
- 최근 및 최종 타겟의 경우 robot_path를 split하여 분리한다음 첫번째 요소와 두번째 요소를 각각 뽑아서 렌더링
